### PR TITLE
Add missing axios dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,22 @@
 {
   "name": "node-red-contrib-smart-prices",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+    },
     "luxon": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Martti Kuldma",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.24.0",
     "luxon": "^2.3.0"
   }
 }


### PR DESCRIPTION
Module won't run on raspberry pi version of nodered because of missing axios module. It was probably installed globally on yours or maybe required by other modules.